### PR TITLE
Added backslash to SimpleXMLElement

### DIFF
--- a/lib/Badcow/eWay/eWay.php
+++ b/lib/Badcow/eWay/eWay.php
@@ -1238,7 +1238,7 @@ class eWay
      */
     public function setPaymentXML()
     {
-        $xml = new SimpleXMLElement('<ewaygateway/>');
+        $xml = new \SimpleXMLElement('<ewaygateway/>');
 
         if(isset($this->customerID)) $xml->addChild('ewayCustomerID', $this->customerID);
         if(isset($this->paymentAmount)) $xml->addChild('ewayTotalAmount', $this->paymentAmount);


### PR DESCRIPTION
SimpleXMLElement class not found if lib is namespaced. The backslash should fix that... Putting use \SimpleXMLElement; at the top should do it too, but a bit overkill.
