### PR TITLE
Update eWay.php

### DIFF
--- a/lib/Badcow/eWay/eWay.php
+++ b/lib/Badcow/eWay/eWay.php
@@ -972,7 +972,7 @@ class eWay
      */
     public function setCustomerEmail($email)
     {
-        if(!preg_match('/^[\w-\.]+@(?:[\w]+\.)+[a-zA-Z]{2,4}$/', $email))
+        if(!preg_match('/^\w+([-+.\']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/', $email))
         {
             throw new ErrorException('Invalid email address.');
         }


### PR DESCRIPTION
The regex in `setCustomerEmail()` doesn't allow dashes in domain names. The regex in this PR is more forgiving, sourced from http://stackoverflow.com/a/201336/551093
